### PR TITLE
allow DOM objects directly instead of their id

### DIFF
--- a/js/bigUpload.js
+++ b/js/bigUpload.js
@@ -74,8 +74,8 @@ function bigUpload () {
 	parent = this;
 
 	//Quick function for accessing objects
-	this.$ = function(id) {
-		return document.getElementById(id);
+	this.$ = function(e) {
+		return typeof e === 'string' ? document.getElementById(e) : e;
 	};
 
 	//Resets all the upload specific data before a new upload


### PR DESCRIPTION
This can be useful when dealing with dynamic object, when we already have a reference to the object and / or when we don't want to set an id.