### PR TITLE
Enhance IE detection

### DIFF
--- a/js/bigUpload.js
+++ b/js/bigUpload.js
@@ -218,7 +218,7 @@ function bigUpload () {
 		};
 
 		//checks if browser is Internet Explorer (IE FileReader doesn't have the readAsBinaryString method) 
-		var isIE = (navigator.userAgent.indexOf("MSIE") != -1);
+		var isIE = ((navigator.userAgent.indexOf("MSIE") != -1) || (navigator.userAgent.indexOf("Trident") != -1));
 		
 		//Slice the file into the desired chunk
 		//This is the core of the script. Everything else is just fluff.


### PR DESCRIPTION
Hi man,
I noticed that IE 11 is not correctly detected and so, does not work because of `readAsBinaryString` problem. On my Windows Seven x64 fully patched my user-agent is : `Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; rv:11.0) like Gecko` so #12 no longer works.

I found that Microsoft has modified the user agent of IE 11 and has removed the string `MSIE` ([source](https://msdn.microsoft.com/en-us/library/hh869301%28v=vs.85%29.aspx#ie11)).
I added `Trident` string detection in addition to `MSIE`.

Thanks 